### PR TITLE
Return the whole body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export default function(password, production=true) {
       throw new VerificationError(statusCodes[body.status]);
     }
 
-    return receipt;
+    return body;
   }
 }
 


### PR DESCRIPTION
Why just return the receipt?  The body has all the expiration dates for subscriptions.
